### PR TITLE
Update cipher.go

### DIFF
--- a/rsa/cipher.go
+++ b/rsa/cipher.go
@@ -5,7 +5,7 @@ import (
 	"crypto"
 
 	"errors"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 type Cipher interface {


### PR DESCRIPTION
github.com/89hmdys/toast/rsa imports
        github.com/Sirupsen/logrus: github.com/Sirupsen/logrus@v1.4.2: parsing go.mod:
        module declares its path as: github.com/sirupsen/logrus
                but was required as: github.com/Sirupsen/logrus