### PR TITLE
Update cipher.go

### DIFF
--- a/rsa/cipher.go
+++ b/rsa/cipher.go
@@ -5,7 +5,7 @@ import (
 	"crypto"
 
 	"errors"
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 )
 
 type Cipher interface {


### PR DESCRIPTION
correcting import as facing issue :
          module declares its path as: github.com/sirupsen/logrus
	  but was required as: github.com/Sirupsen/logrus